### PR TITLE
Translated labels aren't displayed

### DIFF
--- a/admin_views/templatetags/admin_views.py
+++ b/admin_views/templatetags/admin_views.py
@@ -26,7 +26,7 @@ def get_admin_views(app_name):
                     alt_text = "Custom admin view '%s'" % name
 
                 output.append(
-                        """<tr>
+                        u"""<tr>
                               <th scope="row">
                                   <img src="%s" alt="%s" />
                                   <a href="%s">%s</a></th>


### PR DESCRIPTION
If I have

```
from django.utils.translation import ugettext_lazy as _

# ...

class MyAdmin(AdminViews):
    admin_views = (
        (_('My Label'), 'http://my.link.com/'),
    )
```

then only an icon is visible in the admin interface, and the label "My Label" is missing.
