### PR TITLE
fixed compatibility with django 1.6 (django.conf.urls.defaults is gone)

### DIFF
--- a/admin_views/admin.py
+++ b/admin_views/admin.py
@@ -1,7 +1,6 @@
 from functools import update_wrapper
 from django.contrib import admin
-from django.conf.urls import url
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 class AdminViews(admin.ModelAdmin):
     """


### PR DESCRIPTION
No more 'ImportError: No module named defaults' in Django 1.6.
