### PR TITLE
Update for django 3

### DIFF
--- a/admin_views/templates/admin/index.html
+++ b/admin_views/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_views %}
+{% load i18n static admin_views %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}" />{% endblock %}
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         ]
     },
     install_requires=[
-        'django>=1.6',
+        'django>=3.0',
     ],
     tests_require=['django-coverage', 'coverage'],
     classifiers=[


### PR DESCRIPTION
`admin_static` has been replaced by `static` in django 3.